### PR TITLE
Use 95% of the width as the drag threshold

### DIFF
--- a/Classes/ITRAirSideMenu.m
+++ b/Classes/ITRAirSideMenu.m
@@ -3,6 +3,7 @@
 
 @interface ITRAirSideMenu ()
 
+@property (assign, readwrite, nonatomic) CGFloat actionThreshold;
 @property (assign, readwrite, nonatomic) CGFloat totalAngle;
 @property (assign, readwrite, nonatomic) CGPoint lastPoint;
 @property (strong, readwrite, nonatomic) UIImageView *backgroundImageView;
@@ -45,27 +46,43 @@
 {
     _menuViewContainer = [[UIView alloc] init];
     _contentViewContainer = [[UIView alloc] init];
-    
+
     _animationDuration = 0.35f;
     _interactivePopGestureRecognizerEnabled = YES;
-    
+
     _panGestureEnabled = YES;
     _panFromEdge = YES;
     _panMinimumOpenThreshold = 60.0;
-    
+
     _contentViewShadowEnabled = NO;
     _contentViewShadowColor = [UIColor blackColor];
     _contentViewShadowOffset = CGSizeZero;
     _contentViewShadowOpacity = 0.4f;
     _contentViewShadowRadius = 8.0f;
     _contentViewFadeOutAlpha = 1.0f;
-    
+
     _contentViewScaleValue = 0.7f;
     _contentViewRotatingAngle = 30.0f;
     _contentViewTranslateX = 150.0f;
-    
+
     _menuViewRotatingAngle = 30.0f;
     _menuViewTranslateX = 150.0f;
+}
+
+- (void)viewWillAppear:(BOOL)animated
+{
+    [super viewWillAppear:animated];
+
+    self.actionThreshold = 0;
+}
+
+- (void)viewDidLayoutSubviews
+{
+    [super viewDidLayoutSubviews];
+
+    if (self.actionThreshold == 0) {
+        self.actionThreshold = (NSInteger)MAX(300, 0.95 * CGRectGetWidth(self.contentViewContainer.bounds));
+    }
 }
 
 #pragma mark -
@@ -75,7 +92,7 @@
 {
     self = [self init];
     if (self) {
-        
+
         _contentViewController = contentViewController;
         _leftMenuViewController = leftMenuViewController;
     }
@@ -99,26 +116,26 @@
     {
         return;
     }
-    
+
     //contentview controller updated
     if (!animated) {
         [self setContentViewController:contentViewController];
     } else {
-        
+
         [self addChildViewController:contentViewController];
         contentViewController.view.alpha = 0;
         contentViewController.view.frame = self.contentViewContainer.bounds;
         contentViewController.view.layer.transform = self.contentViewController.view.layer.transform;
         contentViewController.view.superview.layer.sublayerTransform = _contentViewController.view.superview.layer.sublayerTransform;
         [self.contentViewContainer addSubview:contentViewController.view];
-        
+
         [UIView animateWithDuration:self.animationDuration animations:^{
             contentViewController.view.alpha = 1;
         } completion:^(BOOL finished) {
             [self hideViewController:self.contentViewController];
             [contentViewController didMoveToParentViewController:self];
             _contentViewController = contentViewController;
-            
+
             [self updateContentViewShadow];
         }];
     }
@@ -129,9 +146,9 @@
 - (void)viewDidLoad
 {
     [super viewDidLoad];
-    
+
     self.view.autoresizingMask = UIViewAutoresizingFlexibleWidth | UIViewAutoresizingFlexibleHeight;
-    
+
     self.backgroundImageView = ({
         UIImageView *imageView = [[UIImageView alloc] initWithFrame:self.view.bounds];
         imageView.image = self.backgroundImage;
@@ -144,41 +161,41 @@
         [button addTarget:self action:@selector(hideMenuViewController) forControlEvents:UIControlEventTouchUpInside];
         button;
     });
-    
+
     [self.view addSubview:self.backgroundImageView];
     [self.view addSubview:self.menuViewContainer];
     [self.view addSubview:self.contentViewContainer];
     [self.view bringSubviewToFront:self.contentViewContainer];
-    
+
     self.menuViewContainer.frame = self.view.bounds;
     self.menuViewContainer.autoresizingMask = UIViewAutoresizingFlexibleWidth | UIViewAutoresizingFlexibleHeight;
-    
+
     if (self.leftMenuViewController) {
-        
+
         [self addChildViewController:self.leftMenuViewController];
         self.leftMenuViewController.view.frame = self.view.bounds;
         self.leftMenuViewController.view.autoresizingMask = UIViewAutoresizingFlexibleWidth | UIViewAutoresizingFlexibleHeight;
-        
+
         [self.menuViewContainer addSubview:self.leftMenuViewController.view];
         [self.leftMenuViewController didMoveToParentViewController:self];
     }
-    
+
     self.contentViewContainer.frame = self.view.bounds;
     self.contentViewContainer.autoresizingMask = UIViewAutoresizingFlexibleWidth | UIViewAutoresizingFlexibleHeight;
-    
+
     [self addChildViewController:self.contentViewController];
     self.contentViewController.view.frame = self.view.bounds;
     [self.contentViewContainer addSubview:self.contentViewController.view];
     [self.contentViewController didMoveToParentViewController:self];
-    
-    
+
+
     if (self.panGestureEnabled) {
         self.view.multipleTouchEnabled = NO;
         UIPanGestureRecognizer *panGestureRecognizer = [[UIPanGestureRecognizer alloc] initWithTarget:self action:@selector(panGestureRecognized:)];
         panGestureRecognizer.delegate = self;
         [_contentViewContainer addGestureRecognizer:panGestureRecognizer];
     }
-    
+
     [_contentViewContainer setBackgroundColor:[UIColor clearColor]];
     [self updateContentViewShadow];
 }
@@ -213,25 +230,25 @@
     if (!self.leftMenuViewController) {
         return;
     }
-    
+
     if (!self.visible && [self.delegate conformsToProtocol:@protocol(ITRAirSideMenuDelegate)] && [self.delegate respondsToSelector:@selector(sideMenu:willShowMenuViewController:)]) {
         [self.delegate sideMenu:self willShowMenuViewController:_leftMenuViewController];
     }
-    
+
     [self.leftMenuViewController beginAppearanceTransition:YES animated:YES];
     self.leftMenuViewController.view.hidden = NO;
     [self.view.window endEditing:YES];
-    
+
     [self addContentButton];
     [self updateContentViewShadow];
-    
+
     //anchor point set to change the origin of rotation. value ranges from 0 to 1.0 (0 to width/height)
     [self setAnchorPoint:CGPointMake(0.0, 0.5) forView:_menuViewContainer];
     [self setAnchorPoint:CGPointMake(1.0, 0.5) forView:_contentViewContainer];
     [self setAnchorPoint:CGPointMake(1.0, 0.5) forView:_contentViewController.view];
-    
+
     [UIView animateWithDuration:self.animationDuration delay:0 options:UIViewAnimationOptionCurveEaseOut animations:^{
-        
+
         //content view scale transform
         CATransform3D contentScaleTransform =  _contentViewContainer.layer.transform;
         contentScaleTransform = CATransform3DMakeScale(_contentViewScaleValue, _contentViewScaleValue,1.0f);
@@ -263,17 +280,17 @@
         }
 
         _menuViewContainer.layer.transform = CATransform3DIdentity;
-        
+
     } completion:^(BOOL finished) {
-        
+
         self.isLeftMenuVisible = YES;
-        
+
         if (!self.visible && [self.delegate conformsToProtocol:@protocol(ITRAirSideMenuDelegate)] && [self.delegate respondsToSelector:@selector(sideMenu:didShowMenuViewController:)]) {
             [self.delegate sideMenu:self didShowMenuViewController:_leftMenuViewController];
         }
         self.visible = YES;
     }];
-    
+
 }
 
 
@@ -289,55 +306,55 @@
 {
     UIViewController *visibleMenuViewController = self.leftMenuViewController;
     [visibleMenuViewController beginAppearanceTransition:NO animated:animated];
-    
+
     if (self.visible && [self.delegate conformsToProtocol:@protocol(ITRAirSideMenuDelegate)] && [self.delegate respondsToSelector:@selector(sideMenu:willHideMenuViewController:)]) {
         [self.delegate sideMenu:self willHideMenuViewController:self.leftMenuViewController];
     }
-    
+
     __typeof (self) __weak weakSelf = self;
     void (^animationBlock)(void) = ^{
         __typeof (weakSelf) __strong strongSelf = weakSelf;
         if (!strongSelf) {
             return;
         }
-        
-            
-            //content view scale transform
-            CATransform3D contentScaleTransform =  _contentViewContainer.layer.transform;
-            contentScaleTransform = CATransform3DMakeScale(1.0, 1.0,1.0f);
-            _contentViewContainer.layer.transform = contentScaleTransform;
 
-            if (_contentViewRotatingAngle != 0) {
-                //content view rotate transform
-                CATransform3D contentRotateTransform =  _contentViewController.view.layer.transform;
-                contentRotateTransform = CATransform3DMakeRotation(0 * M_PI/180.0f, 0.0f, 1.0f, 0.0f);
-                CATransform3D sublayerTransform = _contentViewController.view.superview.layer.sublayerTransform;
-                sublayerTransform.m34 = 1.0f / -300.0f;
-                _contentViewController.view.superview.layer.sublayerTransform = sublayerTransform;
-                _contentViewController.view.layer.transform = contentRotateTransform;
-            }
 
-            //content view translate transform
-            CATransform3D contentTranslateTransform = _contentViewContainer.layer.transform;
-            contentTranslateTransform = CATransform3DTranslate(contentTranslateTransform, 0, 0, 0);
-            _contentViewContainer.layer.transform = contentTranslateTransform;
+        //content view scale transform
+        CATransform3D contentScaleTransform =  _contentViewContainer.layer.transform;
+        contentScaleTransform = CATransform3DMakeScale(1.0, 1.0,1.0f);
+        _contentViewContainer.layer.transform = contentScaleTransform;
 
-            if (_menuViewRotatingAngle != 0) {
-                //menu view rotate transform
-                CATransform3D menuRotateTransform =  _leftMenuViewController.view.layer.transform;
-                menuRotateTransform = CATransform3DMakeRotation(_menuViewRotatingAngle * M_PI/180.0f, 0.0f, -1.0f, 0.0f);
-                CATransform3D sublayerTransform1 = _leftMenuViewController.view.superview.layer.sublayerTransform;
-                sublayerTransform1.m34 = 1.0f / -300.0f;
-                _leftMenuViewController.view.superview.layer.sublayerTransform = sublayerTransform1;
-                _leftMenuViewController.view.layer.transform = menuRotateTransform;
-            }
+        if (_contentViewRotatingAngle != 0) {
+            //content view rotate transform
+            CATransform3D contentRotateTransform =  _contentViewController.view.layer.transform;
+            contentRotateTransform = CATransform3DMakeRotation(0 * M_PI/180.0f, 0.0f, 1.0f, 0.0f);
+            CATransform3D sublayerTransform = _contentViewController.view.superview.layer.sublayerTransform;
+            sublayerTransform.m34 = 1.0f / -300.0f;
+            _contentViewController.view.superview.layer.sublayerTransform = sublayerTransform;
+            _contentViewController.view.layer.transform = contentRotateTransform;
+        }
 
-            //menu view translate transform
-            CATransform3D menuTranslateTransform = CATransform3DIdentity;
-            menuTranslateTransform = CATransform3DTranslate(menuTranslateTransform, -_menuViewTranslateX, 0, 0);
-            _menuViewContainer.layer.transform = menuTranslateTransform;
-            
-     };
+        //content view translate transform
+        CATransform3D contentTranslateTransform = _contentViewContainer.layer.transform;
+        contentTranslateTransform = CATransform3DTranslate(contentTranslateTransform, 0, 0, 0);
+        _contentViewContainer.layer.transform = contentTranslateTransform;
+
+        if (_menuViewRotatingAngle != 0) {
+            //menu view rotate transform
+            CATransform3D menuRotateTransform =  _leftMenuViewController.view.layer.transform;
+            menuRotateTransform = CATransform3DMakeRotation(_menuViewRotatingAngle * M_PI/180.0f, 0.0f, -1.0f, 0.0f);
+            CATransform3D sublayerTransform1 = _leftMenuViewController.view.superview.layer.sublayerTransform;
+            sublayerTransform1.m34 = 1.0f / -300.0f;
+            _leftMenuViewController.view.superview.layer.sublayerTransform = sublayerTransform1;
+            _leftMenuViewController.view.layer.transform = menuRotateTransform;
+        }
+
+        //menu view translate transform
+        CATransform3D menuTranslateTransform = CATransform3DIdentity;
+        menuTranslateTransform = CATransform3DTranslate(menuTranslateTransform, -_menuViewTranslateX, 0, 0);
+        _menuViewContainer.layer.transform = menuTranslateTransform;
+
+    };
     void (^completionBlock)(void) = ^{
         __typeof (weakSelf) __strong strongSelf = weakSelf;
         if (!strongSelf) {
@@ -345,15 +362,15 @@
         }
         [visibleMenuViewController endAppearanceTransition];
         [self.contentButton removeFromSuperview];
-        
+
         strongSelf.isLeftMenuVisible = NO;
-        
+
         if (strongSelf.visible && [strongSelf.delegate conformsToProtocol:@protocol(ITRAirSideMenuDelegate)] && [strongSelf.delegate respondsToSelector:@selector(sideMenu:didHideMenuViewController:)]) {
             [strongSelf.delegate sideMenu:strongSelf didHideMenuViewController:strongSelf.leftMenuViewController];
         }
         strongSelf.visible = NO;
     };
-    
+
     if (animated) {
         [[UIApplication sharedApplication] beginIgnoringInteractionEvents];
         [UIView animateWithDuration:self.animationDuration delay:0 options:UIViewAnimationOptionCurveEaseOut animations:^{
@@ -373,7 +390,7 @@
 {
     if (self.contentButton.superview)
         return;
-    
+
     self.contentButton.autoresizingMask = UIViewAutoresizingNone;
     self.contentButton.frame = self.contentViewContainer.bounds;
     self.contentButton.autoresizingMask = UIViewAutoresizingFlexibleWidth | UIViewAutoresizingFlexibleHeight;
@@ -423,7 +440,7 @@
             }
         }
     }else {
-        
+
         if (self.panFromEdge && [gestureRecognizer isKindOfClass:[UIPanGestureRecognizer class]] && !self.visible) {
             CGPoint point = [touch locationInView:gestureRecognizer.view];
             if (point.x < 20.0 || point.x > self.view.frame.size.width - 20.0) {
@@ -434,7 +451,7 @@
         }
 
     }
-    
+
     return YES;
 }
 
@@ -445,39 +462,39 @@
 {
     if ([self.delegate conformsToProtocol:@protocol(ITRAirSideMenuDelegate)] && [self.delegate respondsToSelector:@selector(sideMenu:didRecognizePanGesture:)])
         [self.delegate sideMenu:self didRecognizePanGesture:recognizer];
-    
+
     if (!self.panGestureEnabled) {
         return;
     }
-    
+
     CGPoint point = [recognizer translationInView:self.view];
-    
+
     if (recognizer.state == UIGestureRecognizerStateBegan) {
         [self updateContentViewShadow];
         _totalAngle = 0;
         _lastPoint = CGPointMake(0, 0);
-        
+
         [self addContentButton];
         [self.view.window endEditing:YES];
         self.didNotifyDelegate = NO;
     }
-    
+
     if (recognizer.state == UIGestureRecognizerStateChanged) {
-        
+
         CGPoint newLocationPoint = point;
         if(newLocationPoint.x < 0)
-            newLocationPoint.x = 300 + newLocationPoint.x;
-        
+            newLocationPoint.x = self.actionThreshold + newLocationPoint.x;
+
         //track movement
-        if((newLocationPoint.x >= 0 && newLocationPoint.x <= 300))
+        if((newLocationPoint.x >= 0 && newLocationPoint.x <= self.actionThreshold))
         {
             [self setAnchorPoint:CGPointMake(1.0, 0.5) forView:_contentViewContainer];
             [self setAnchorPoint:CGPointMake(1.0, 0.5) forView:_contentViewController.view];
-            
+
             //calculation of scale, angle & translate for content view based on pan position
-            CGFloat contentViewScale = 1 + (_contentViewScaleValue - 1)* (newLocationPoint.x / 300);
-            CGFloat angle = (newLocationPoint.x - _lastPoint.x) * _contentViewRotatingAngle/300;
-            CGFloat tranformX = newLocationPoint.x * _contentViewTranslateX/300;
+            CGFloat contentViewScale = 1 + (_contentViewScaleValue - 1)* (newLocationPoint.x / self.actionThreshold);
+            CGFloat angle = (newLocationPoint.x - _lastPoint.x) * _contentViewRotatingAngle/self.actionThreshold;
+            CGFloat tranformX = newLocationPoint.x * _contentViewTranslateX/self.actionThreshold;
 
             _totalAngle = _totalAngle + angle;
 
@@ -504,7 +521,7 @@
 
             //calculation of scale, angle & translate for menu view based on pan position
             if (angle != 0) {
-                CGFloat menuAngle = _menuViewRotatingAngle - (newLocationPoint.x) * _menuViewRotatingAngle/300;
+                CGFloat menuAngle = _menuViewRotatingAngle - (newLocationPoint.x) * _menuViewRotatingAngle/self.actionThreshold;
 
                 //menu view rotate transform
                 CATransform3D menuRotateTransform =  _leftMenuViewController.view.layer.transform;
@@ -515,7 +532,7 @@
                 _leftMenuViewController.view.layer.transform = menuRotateTransform;
             }
 
-            CGFloat menuTransformValue = (_menuViewTranslateX * newLocationPoint.x/300) - _menuViewTranslateX - _menuViewContainer.frame.origin.x;
+            CGFloat menuTransformValue = (_menuViewTranslateX * newLocationPoint.x/self.actionThreshold) - _menuViewTranslateX - _menuViewContainer.frame.origin.x;
 
             //menu view translate transform
             CATransform3D menuTranslateTransform = _menuViewContainer.layer.transform;
@@ -524,24 +541,24 @@
 
             _lastPoint.x = newLocationPoint.x;
         }
-        
-        
+
+
         self.leftMenuViewController.view.hidden = self.contentViewContainer.frame.origin.x < 0;
-        
+
         if (!self.leftMenuViewController && self.contentViewContainer.frame.origin.x > 0) {
-            
+
             self.contentViewContainer.transform = CGAffineTransformIdentity;
             self.contentViewContainer.frame = self.view.bounds;
             self.visible = NO;
             self.isLeftMenuVisible = NO;
         }
-        
+
     }
-    
+
     if (recognizer.state == UIGestureRecognizerStateEnded) {
-        
+
         self.didNotifyDelegate = NO;
-        
+
         // if minimum open threshold not satisfied, left menu is closed again
         if (self.panMinimumOpenThreshold > 0 && (self.contentViewContainer.frame.origin.x > 0 && self.contentViewContainer.frame.origin.x < self.panMinimumOpenThreshold))
         {
@@ -551,19 +568,19 @@
             [self hideMenuViewControllerAnimated:NO];
         }
         else {
-                if (self.contentViewContainer.frame.origin.x < 0) {
+            if (self.contentViewContainer.frame.origin.x < 0) {
+                [self hideMenuViewController];
+            } else {
+                if (self.isLeftMenuVisible && (self.actionThreshold - _lastPoint.x) > self.panMinimumOpenThreshold) {
                     [self hideMenuViewController];
-                } else {
-                    if (self.isLeftMenuVisible && (300 - _lastPoint.x) > self.panMinimumOpenThreshold) {
-                        [self hideMenuViewController];
-                    }
-                    else if (self.leftMenuViewController) {
-                        [self showLeftMenuViewController];
-                    }
                 }
+                else if (self.leftMenuViewController) {
+                    [self showLeftMenuViewController];
+                }
+            }
         }
     }
-    
+
 }
 
 #pragma mark -
@@ -583,19 +600,19 @@
         return;
     }
     [self hideViewController:_contentViewController];
-    
+
     contentViewController.view.layer.transform = _contentViewController.view.layer.transform;
     contentViewController.view.layer.sublayerTransform = _contentViewController.view.layer.sublayerTransform;
     _contentViewController = contentViewController;
-    
+
     [self addChildViewController:self.contentViewController];
     [self.contentViewContainer addSubview:self.contentViewController.view];
     [self.contentViewController didMoveToParentViewController:self];
-    
+
     [self updateContentViewShadow];
-    
-    
-   // [self hideMenuViewController];
+
+
+    // [self hideMenuViewController];
 }
 - (void)setLeftMenuViewController:(UIViewController *)leftMenuViewController
 {
@@ -605,26 +622,26 @@
     }
     [self hideViewController:_leftMenuViewController];
     _leftMenuViewController = leftMenuViewController;
-    
+
     [self addChildViewController:self.leftMenuViewController];
     self.leftMenuViewController.view.frame = self.view.bounds;
     self.leftMenuViewController.view.autoresizingMask = UIViewAutoresizingFlexibleWidth | UIViewAutoresizingFlexibleHeight;
     [self.menuViewContainer addSubview:self.leftMenuViewController.view];
     [self.leftMenuViewController didMoveToParentViewController:self];
-    
+
 }
 
 #pragma mark - Utilities
 - (void)setAnchorPoint:(CGPoint)anchorPoint forView:(UIView *)view {
-    
+
     CGPoint oldOrigin = view.frame.origin;
     view.layer.anchorPoint = anchorPoint;
     CGPoint newOrigin = view.frame.origin;
-    
+
     CGPoint transition;
     transition.x = newOrigin.x - oldOrigin.x;
     transition.y = oldOrigin.y - oldOrigin.y;
-    
+
     view.center = CGPointMake (view.center.x - transition.x, view.center.y - transition.y);
 }
 
@@ -637,7 +654,5 @@
     
     return YES;
 }
-
-
 
 @end


### PR DESCRIPTION
Instead of using a hardcoded value of 300 points, use 95% of the content view container (95% of 320 is 304, which is close enough to 300 for practical purposes, and works better for larger screen sizes).

Also removes a lot of redundant whitespace.
